### PR TITLE
[CMake] Fix building on SFOS 4.6

### DIFF
--- a/rpm/extra-cmake-modules.spec
+++ b/rpm/extra-cmake-modules.spec
@@ -21,10 +21,11 @@ files to perform common tasks and toolchain files that must be specified on the 
 export QTDIR=%{_opt_qt5_prefix}
 
 %{_opt_cmake_kf5}
-%make_build
+%make_build %{?__cmake_builddir:-C "%{__cmake_builddir}"}
 
 %install
-%make_install 
+%{?__cmake_builddir: pushd %{__cmake_builddir}}
+%make_install
 
 %files
 %license COPYING-CMAKE-SCRIPTS

--- a/rpm/extra-cmake-modules.spec
+++ b/rpm/extra-cmake-modules.spec
@@ -14,19 +14,6 @@ The Extra CMake Modules package, or ECM, adds to the modules provided by CMake, 
 used by find_package() to find common software, ones that can be used directly in CMakeLists.txt
 files to perform common tasks and toolchain files that must be specified on the commandline by the user.
 
-
-# define macros for SFOS 4.5 and lower, where the cmake package does not have them:
-# these defines are taken from https://github.com/sailfishos/cmake/blob/master/rpm/macros.cmake.in
-%if %{undefined _cmake_version}
-#%%define __cmake_in_source_build 1
-%define _vpath_srcdir .
-%define _vpath_builddir %{_target_platform}
-%define __cmake_builddir %{!?__cmake_in_source_build:%{_vpath_builddir}}%{?__cmake_in_source_build:.}
-%define cmake_build %__cmake --build "%{__cmake_builddir}" %{?_smp_mflags} --verbose
-%define cmake_install DESTDIR="%{buildroot}" %__cmake --install "%{__cmake_builddir}"
-%endif
-
-
 %prep
 %autosetup -n %{name}-%{version}/upstream
 

--- a/rpm/extra-cmake-modules.spec
+++ b/rpm/extra-cmake-modules.spec
@@ -14,6 +14,19 @@ The Extra CMake Modules package, or ECM, adds to the modules provided by CMake, 
 used by find_package() to find common software, ones that can be used directly in CMakeLists.txt
 files to perform common tasks and toolchain files that must be specified on the commandline by the user.
 
+
+# define macros for SFOS 4.5 and lower, where the cmake package does not have them:
+# these defines are taken from https://github.com/sailfishos/cmake/blob/master/rpm/macros.cmake.in
+%if %{undefined _cmake_version}
+#%%define __cmake_in_source_build 1
+%define _vpath_srcdir .
+%define _vpath_builddir %{_target_platform}
+%define __cmake_builddir %{!?__cmake_in_source_build:%{_vpath_builddir}}%{?__cmake_in_source_build:.}
+%define cmake_build %__cmake --build "%{__cmake_builddir}" %{?_smp_mflags} --verbose
+%define cmake_install DESTDIR="%{buildroot}" %__cmake --install "%{__cmake_builddir}"
+%endif
+
+
 %prep
 %autosetup -n %{name}-%{version}/upstream
 
@@ -21,11 +34,10 @@ files to perform common tasks and toolchain files that must be specified on the 
 export QTDIR=%{_opt_qt5_prefix}
 
 %{_opt_cmake_kf5}
-%make_build %{?__cmake_builddir:-C "%{__cmake_builddir}"}
+%cmake_build
 
 %install
-%{?__cmake_builddir: pushd %{__cmake_builddir}}
-%make_install
+%cmake_install
 
 %files
 %license COPYING-CMAKE-SCRIPTS


### PR DESCRIPTION
Not sure that is the correct way to do it, it's a bit convoluted, but it does make it build on SFOS 4.6, or the new(?) macros from https://github.com/sailfishos-chum/kf5/blob/main/macros.kf5, whichever caused the build failure.

Background:

https://github.com/sailfishos-chum/kf5/blob/244a7f8da6665d20cdf148ef4885bdf67cf17bb7/macros.kf5#L32

When `__cmake_builddir` is defined it is used, and the succeeding `%make_build`/`%make_install` macros do not know about the builddir.